### PR TITLE
Add more items, unit attack_range float not int

### DIFF
--- a/prototype/items/shop.gd
+++ b/prototype/items/shop.gd
@@ -26,7 +26,7 @@ const items = {
 	"Sword of Zanmar": {
 		"name": "Sword of Zanmar",
 		"sprite": 0,
-		"tooltip": "Forged of pure high-carbon steel\nDamage +50, Attack speed +50%",
+		"tooltip": "Forged of pure high-carbon steel\nDamage +50 Attack speed +50%",
 		"attributes": {"damage": 50, "attack_speed": .5},
 		"price": 500,
 		"type": "equip",
@@ -35,7 +35,7 @@ const items = {
 	"Elven Bow": {
 		"name": "Elven Bow",
 		"sprite": 0,
-		"tooltip": "\nDamage +20, Attack speed +25%, Range +40%",
+		"tooltip": "\nDamage +20, Attack speed +25% Range +40%",
 		"attributes": {"damage": 20, "attack_speed": .25, "attack_range": .4},
 		"price": 500,
 		"type": "equip",
@@ -55,7 +55,7 @@ const items = {
 	"Glass Shield": {
 		"name": "Glass Shield",
 		"sprite": 1,
-		"tooltip": "Magically reinforced, stronger than steel\nHealth +200, Vision +50",
+		"tooltip": "Magically reinforced, stronger than steel\nHealth +200 Vision +50",
 		"attributes": {"hp": 200, "vision": 50},
 		"price": 500,
 		"type": "equip",
@@ -64,7 +64,7 @@ const items = {
 	"Dragonscale Armor": {
 		"name": "Dragonscale Armor",
 		"sprite": 1,
-		"tooltip": "No dragons were harmed in the making of this armor\nHealth +300, Defense +4, Speed -10",
+		"tooltip": "No dragons were harmed in the making of this armor\nHealth +300 Defense +4 Speed -10",
 		"attributes": {"hp": 300, "defense": 4, "speed": -10},
 		"price": 500,
 		"type": "equip",
@@ -73,7 +73,7 @@ const items = {
 	"Magic Amulet": {
 		"name": "Magic Amulet",
 		"sprite": 1,
-		"tooltip": "A crystal imbued with magical force\nRegen +2, Speed +15",
+		"tooltip": "A crystal imbued with magical force\nRegen +2 Speed +15",
 		"attributes": {"regen": 2, "speed": 15},
 		"price": 350,
 		"type": "equip",
@@ -103,7 +103,7 @@ const items = {
 	"Oligan's Eye": {
 		"name": "Oligan's Eye",
 		"sprite": 1,
-		"tooltip": "The Eye has helped heroes navigate the battlefield for centuries\nVision +100, Speed +10",
+		"tooltip": "The Eye has helped heroes navigate the battlefield for centuries\nVision +100 Speed +10",
 		"attributes": {"vision": 100, "speed": 10},
 		"price": 350,
 		"type": "equip",

--- a/prototype/items/shop.gd
+++ b/prototype/items/shop.gd
@@ -13,31 +13,129 @@ onready var consumable_items = container.get_node("consumable_items")
 var blacksmiths
 
 const items = {
-	"axe": {
-		"name" :"Axe", 
-		"sprite": 0, 
-		"tooltip": "Adds 25 damage", 
+	# Offensive
+	"Axe": {
+		"name": "Axe",
+		"sprite": 0,
+		"tooltip": "Used to chop wood, now used for war\nDamage +25",
 		"attributes": {"damage": 25},
-		"price": 250,  
-		"type": "equip", 
+		"price": 250,
+		"type": "equip",
 		"delivery_time": 20
 	},
-	"helmet": {
-		"name": "Helmet", 
-		"sprite": 1, 
-		"tooltip": "Adds 150 HP", 
+	"Sword of Zanmar": {
+		"name": "Sword of Zanmar",
+		"sprite": 0,
+		"tooltip": "Forged of pure high-carbon steel\nDamage +50, Attack speed +50%",
+		"attributes": {"damage": 50, "attack_speed": .5},
+		"price": 500,
+		"type": "equip",
+		"delivery_time": 30
+	},
+	"Elven Bow": {
+		"name": "Elven Bow",
+		"sprite": 0,
+		"tooltip": "\nDamage +20, Attack speed +25%, Range +40%",
+		"attributes": {"damage": 20, "attack_speed": .25, "attack_range": .4},
+		"price": 500,
+		"type": "equip",
+		"delivery_time": 30
+	},
+
+	# Defensive
+	"Helmet": {
+		"name": "Helmet",
+		"sprite": 1,
+		"tooltip": "Adds 150 HP",
 		"attributes": {"hp": 150},
-		"price": 300, 
-		"type": "equip", 
+		"price": 300,
+		"type": "equip",
 		"delivery_time": 25
 	},
-	"potion": {
-		"name": "Potion", 
-		"sprite": 2, 
+	"Glass Shield": {
+		"name": "Glass Shield",
+		"sprite": 1,
+		"tooltip": "Magically reinforced, stronger than steel\nHealth +200, Vision +50",
+		"attributes": {"hp": 200, "vision": 50},
+		"price": 500,
+		"type": "equip",
+		"delivery_time": 25
+	},
+	"Dragonscale Armor": {
+		"name": "Dragonscale Armor",
+		"sprite": 1,
+		"tooltip": "No dragons were harmed in the making of this armor\nHealth +300, Defense +4, Speed -10",
+		"attributes": {"hp": 300, "defense": 4, "speed": -10},
+		"price": 500,
+		"type": "equip",
+		"delivery_time": 25
+	},
+	"Magic Amulet": {
+		"name": "Magic Amulet",
+		"sprite": 1,
+		"tooltip": "A crystal imbued with magical force\nRegen +2, Speed +15",
+		"attributes": {"regen": 2, "speed": 15},
+		"price": 350,
+		"type": "equip",
+		"delivery_time": 15
+	},
+
+
+	# Utility
+	"Boots": {
+		"name": "Boots",
+		"sprite": 1,
+		"tooltip": "Protect your feet from the ground\nSpeed +15",
+		"attributes": {"speed": 15},
+		"price": 300,
+		"type": "equip",
+		"delivery_time": 25
+	},
+	"Telescope": {
+		"name": "Telescope",
+		"sprite": 1,
+		"tooltip": "Crafted with precision-forged glass\nVision +50",
+		"attributes": {"vision": 50},
+		"price": 150,
+		"type": "equip",
+		"delivery_time": 15
+	},
+	"Oligan's Eye": {
+		"name": "Oligan's Eye",
+		"sprite": 1,
+		"tooltip": "The Eye has helped heroes navigate the battlefield for centuries\nVision +100, Speed +10",
+		"attributes": {"vision": 100, "speed": 10},
+		"price": 350,
+		"type": "equip",
+		"delivery_time": 25
+	},
+
+	# Consumables
+	"Small Health": {
+		"name": "Small Health",
+		"sprite": 2,
 		"tooltip": "Restore 100 HP",
 		"attributes": {"current_hp": 100},
-		"price": 50, 
-		"type": "consumable", 
+		"price": 50,
+		"type": "consumable",
+		"delivery_time": 10
+	},
+	"Medium Health": {
+		"name": "Medium Health",
+		"sprite": 2,
+		"tooltip": "Restore 150 HP",
+		"attributes": {"current_hp": 150},
+		"price": 75,
+		"type": "consumable",
+		"delivery_time": 10
+	},
+	"Large Health": {
+		"name": "Large Health",
+		"sprite": 2,
+		"tooltip": "Restore 250 HP",
+		"attributes": {"current_hp": 250},
+		"price": 125,
+		"type": "consumable",
 		"delivery_time": 10
 	}
 }

--- a/prototype/unit/unit.gd
+++ b/prototype/unit/unit.gd
@@ -50,7 +50,7 @@ export var attacks:bool = false
 export var ranged:bool = false
 var stunned:bool = false
 export var damage:int = 0
-export var attack_range:int = 1
+export var attack_range:float = 1
 export var attack_speed:float = 1
 export var defense:int = 0
 var target:Node2D


### PR DESCRIPTION
Added a couple items, they haven't been really playtested for balance but they shouldn't be too crazy. No special icons for them yet, but that will be easy to adjust later. For issue #56.

Changed unit's attack_range to be a float instead of an int, because setting it to 2 is way too overpowered but being able to set it to 1.4 or so is a decent item powerup.