### PR TITLE
Fixed an issue with the TAB button

### DIFF
--- a/prototype/controls/selection.gd
+++ b/prototype/controls/selection.gd
@@ -9,7 +9,6 @@ func _ready():
 
 func _unhandled_input(event):
 	var point = game.camera.get_global_mouse_position()
-	var score_board = game.ui.get_node("score_board")
 	
 	# KEYBOARD
 	if event is InputEventKey:
@@ -28,11 +27,7 @@ func _unhandled_input(event):
 						KEY_S: stand(game.selected_unit)
 					
 				game.unit.follow.draw_path(game.selected_unit)
-		if event.scancode == KEY_TAB and score_board.is_ready:
-			score_board.visible = event.is_pressed()
-		
 
-	
 	# CLICK SELECTION
 	if event is InputEventMouseButton and not event.pressed: 
 		if game.camera.zoom.x <= 1:

--- a/prototype/project.godot
+++ b/prototype/project.godot
@@ -78,6 +78,10 @@ ui_accept={
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
  ]
 }
+ui_focus_next={
+"deadzone": 0.5,
+"events": [  ]
+}
 pan={
 "deadzone": 0.5,
 "events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)

--- a/prototype/ui/scoreboard/score_board.gd
+++ b/prototype/ui/scoreboard/score_board.gd
@@ -31,3 +31,10 @@ func update():
 	for container in [team_red_container, team_blue_container]:
 		for child in container.get_children():
 			child.update()
+
+func _unhandled_input(event):
+	if event is InputEventKey:
+		if event.echo:
+			return
+		if event.scancode == KEY_TAB and is_ready:			
+			visible = event.is_pressed()


### PR DESCRIPTION
TAB button was captured by the UI "ui_focus_next" action mapped in project settings. I've removed the mapping and now scoreboard always appears when pressing TAB.