### PR TITLE
Fix cheat console not releasing focus

### DIFF
--- a/prototype/ui/cheat_console.gd
+++ b/prototype/ui/cheat_console.gd
@@ -6,4 +6,5 @@ func _gui_input(event):
 			var code = text
 			text = ""
 			EventMachine.register_event(Events.CHEAT_CODE, [code])
+			release_focus()
 			


### PR DESCRIPTION
Fixed cheat console not releasing focus after a cheat code has been used. This prevented the use of keyboard commands like showing scoreboard or order button shortcuts.