### PR TITLE
Fix typo in team selection menu

### DIFF
--- a/prototype/leaders/arthur.tscn
+++ b/prototype/leaders/arthur.tscn
@@ -549,6 +549,7 @@ projectile_speed = 0.0
 
 [node name="aura_of_courage" parent="behavior/abilities" index="0" instance=ExtResource( 2 )]
 icon = ExtResource( 5 )
+description = "Arthur inspires courage in nearby allies, increasing their attack by 2 x his level"
 
 [node name="symbol" parent="." index="1"]
 modulate = Color( 1, 1, 1, 1 )

--- a/prototype/ui/team_selection/team_selection_menu.tscn
+++ b/prototype/ui/team_selection/team_selection_menu.tscn
@@ -50,7 +50,7 @@ size_flags_vertical = 3
 margin_right = 217.0
 margin_bottom = 18.0
 custom_fonts/font = ExtResource( 1 )
-text = "team bue"
+text = "team blue"
 align = 1
 valign = 1
 


### PR DESCRIPTION
Fixed typo in team selection menu (bue -> blue) and modified ability description for Aura of Courage (2 * his level -> 2 x his level)