### PR TITLE
Add unique item passives

### DIFF
--- a/prototype/abilites/multishot.gd
+++ b/prototype/abilites/multishot.gd
@@ -13,7 +13,7 @@ export(String, MULTILINE) var description = "This unit can shoot at all enemy ch
 export var status_effect_icon : Texture
 
 func _ready():
-	unit.status_effects["mutlishot"] = {
+	unit.status_effects["multishot"] = {
 		icon = status_effect_icon,
 		hint = "Multishot: target all enemies in range"
 	}

--- a/prototype/items/inventories.gd
+++ b/prototype/items/inventories.gd
@@ -24,7 +24,7 @@ var sell_button_margin = 40
 
 func _ready():
 	game = get_tree().get_current_scene()
-	
+
 	hide()
 	clear()
 
@@ -43,7 +43,7 @@ func new_inventory(leader):
 		var leader_skills = game.unit.skills.leader[leader.display_name]
 		if "extra_gold" in leader_skills:
 				extra_skill_gold = leader_skills.extra_gold
-	
+
 	var inventory = {
 		"container": HBoxContainer.new(),
 		"extra_skill_gold": extra_skill_gold,
@@ -55,7 +55,7 @@ func new_inventory(leader):
 		"equip_item_buttons": [],
 		"consumable_item_buttons": []
 	}
-	
+
 	inventory.container.margin_top = sell_button_margin
 # warning-ignore:unused_variable
 	for index in range(equip_items_max):
@@ -71,8 +71,8 @@ func build_leaders():
 		add_inventory(leader)
 	for leader in game.enemy_leaders:
 		add_inventory(leader)
-	
-	
+
+
 	var timer := Timer.new()
 	timer.wait_time = 1
 	game.ui.get_node("bot_mid").add_child(timer)
@@ -94,7 +94,7 @@ func set_leader_inventory(leader, inventory):
 		var inv = player_leaders_inv
 		if not leader.team == game.player_team:
 			inv = enemy_leaders_inv
-			
+
 		inventory.leader = leader
 		inv[leader.name] = inventory
 
@@ -154,7 +154,7 @@ func gold_timer(unit):
 	timer.start()
 # warning-ignore:return_value_discarded
 	timer.connect("timeout", self, "gold_timer_timeout", [unit])
-	
+
 
 func gold_timer_timeout(unit):
 	if not game.paused:
@@ -198,7 +198,7 @@ func add_delivery(leader, item):
 	}
 	set_leader_delivery(leader, new_delivery)
 	var inventory = get_leader_inventory(leader)
-	
+
 	if item.type == "equip":
 		for index in range(equip_items_max):
 			if inventory.equip_items[index] == null:
@@ -211,7 +211,7 @@ func add_delivery(leader, item):
 				new_delivery.index = index
 				new_delivery.button = inventory.consumable_item_buttons[index]
 				break
-	
+
 	new_delivery.label = new_delivery.button.price_label
 	delivery_timer(new_delivery)
 
@@ -226,7 +226,7 @@ func delivery_timer(delivery):
 			match delivery.item.type:
 				"consumable": give_item(delivery)
 				"equip":
-					if game.ui.shop.close_to_blacksmith(delivery.leader): 
+					if game.ui.shop.close_to_blacksmith(delivery.leader):
 						give_item(delivery)
 					else:
 						var inventory = get_leader_inventory(delivery.leader)
@@ -250,44 +250,47 @@ func give_item(delivery):
 	var inventory = get_leader_inventory(leader)
 	var item = delivery.item
 	var index = delivery.index
-	
+
 	get_leader_delivery(leader).erase(leader.name)
-	
+
 	match item.type:
 		"equip":
 			inventory.equip_items[index] = item
 			inventory.equip_item_buttons[index].setup(item)
 			for key in item.attributes.keys():
 				game.unit.modifiers.add(leader, key, item.name, item.attributes[key])
+			if "passive" in item:
+				var item_scene = load(item.passive)
+				leader.get_node("behavior/item_passives").add_child(item_scene.instance())
 
 		"consumable":
 			inventory.consumable_items[index] = item
 			inventory.consumable_item_buttons[index].setup(item)
-	
+
 	item.delivered = true
-	
+
 	game.unit.hud.update_hpbar(leader)
 
 
 
 func remove_item(leader, index):
 	var inventory = get_leader_inventory(leader)
-	
+
 	var leader_items = inventory.equip_items + inventory.consumable_items
 	var item = leader_items[index]
-	
+
 	if item.type == "equip":
 		# Remove attributes that were added when purchasing an item
 		for key in item.attributes.keys():
 			game.unit.modifiers.remove(leader, key, item.name, item.attributes[key])
-			
+
 		inventory.equip_items[index] = null
-		
+
 	elif item.type == "consumable":
 		inventory.consumable_items[index - equip_items_max] = null
-	
+
 	leader.get_node("hud").update_hpbar(leader)
-	
+
 	return item
 
 
@@ -314,16 +317,16 @@ func update_buttons():
 				if item and item.ready and not item.delivered:
 					var delivery = get_leader_delivery(leader)
 					give_item(delivery)
-	
+
 	if game.selected_leader:
 		var inventory = get_leader_inventory(game.selected_leader)
 		var leader = game.selected_leader
 		var close_to_blacksmith = game.ui.shop.close_to_blacksmith(leader)
-		
+
 		show()
 		inventory.container.show()
 		update_consumables(leader)
-		
+
 		# toggle sell buttons
 		if game.ui.shop.visible and close_to_blacksmith:
 			var counter = 0
@@ -337,4 +340,4 @@ func update_buttons():
 		else:
 			for item_button in inventory.equip_item_buttons + inventory.consumable_item_buttons:
 				item_button.sell_button.hide()
-		
+

--- a/prototype/items/passives/feather.gd
+++ b/prototype/items/passives/feather.gd
@@ -1,0 +1,31 @@
+extends Node
+
+onready var unit : Unit = get_parent().get_parent().get_parent()
+onready var game = get_tree().get_current_scene()
+var affected_units = {}
+
+const RANGE = 100
+const VALUE = 10
+
+export var icon : Texture
+export var ability_name = "Magic Feather"
+export(String, MULTILINE) var description = "The feather helps nearby units move across the battlefield"
+export var status_effect_icon : Texture
+
+func _on_update_timer_timeout():
+	$update_timer.start()
+	for other_unit in affected_units.keys():
+		if (other_unit.global_position - unit.global_position).length() > RANGE:
+			other_unit.modifiers.remove(other_unit, "speed", "feather")
+			affected_units.erase(other_unit)
+			other_unit.status_effects.erase("feather")
+
+	for other_unit in game.map.blocks.get_units_in_radius(unit.global_position, 200):
+		if other_unit.team == unit.team and unit.type != "building":
+			other_unit.modifiers.remove(other_unit, "speed", "feather")
+			other_unit.modifiers.add(other_unit, "speed", "feather", VALUE)
+			affected_units[other_unit] = true
+			other_unit.status_effects["feather"] = {
+				icon = status_effect_icon,
+				hint = "Feather: Increases speed by %d" % (VALUE)
+			}

--- a/prototype/items/passives/feather.tscn
+++ b/prototype/items/passives/feather.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://items/passives/feather.gd" type="Script" id=1]
+
+[node name="feather" type="Node"]
+script = ExtResource( 1 )
+
+[node name="update_timer" type="Timer" parent="."]
+autostart = true
+
+[connection signal="timeout" from="update_timer" to="." method="_on_update_timer_timeout"]

--- a/prototype/items/passives/holy_shield.gd
+++ b/prototype/items/passives/holy_shield.gd
@@ -1,0 +1,31 @@
+extends Node
+
+onready var unit : Unit = get_parent().get_parent().get_parent()
+onready var game = get_tree().get_current_scene()
+var affected_units = {}
+
+const RANGE = 100
+const VALUE = 50
+
+export var icon : Texture
+export var ability_name = "Holy Shield"
+export(String, MULTILINE) var description = "The magic aura protects your soldiers"
+export var status_effect_icon : Texture
+
+func _on_update_timer_timeout():
+	$update_timer.start()
+	for other_unit in affected_units.keys():
+		if (other_unit.global_position - unit.global_position).length() > RANGE:
+			other_unit.modifiers.remove(other_unit, "hp", "holy_shield")
+			affected_units.erase(other_unit)
+			other_unit.status_effects.erase("holy_shield")
+
+	for other_unit in game.map.blocks.get_units_in_radius(unit.global_position, 200):
+		if other_unit.team == unit.team and unit.type != "building":
+			other_unit.modifiers.remove(other_unit, "hp", "holy_shield")
+			other_unit.modifiers.add(other_unit, "hp", "holy_shield", VALUE)
+			affected_units[other_unit] = true
+			other_unit.status_effects["holy_shield"] = {
+				icon = status_effect_icon,
+				hint = "Holy Shield: Increases health by %d" % (VALUE)
+			}

--- a/prototype/items/passives/holy_shield.tscn
+++ b/prototype/items/passives/holy_shield.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://items/passives/holy_shield.gd" type="Script" id=1]
+
+[node name="holy_shield" type="Node"]
+script = ExtResource( 1 )
+
+[node name="update_timer" type="Timer" parent="."]
+autostart = true
+
+[connection signal="timeout" from="update_timer" to="." method="_on_update_timer_timeout"]

--- a/prototype/items/shop.gd
+++ b/prototype/items/shop.gd
@@ -79,8 +79,8 @@ const items = {
 		"type": "equip",
 		"delivery_time": 30
 	},
-	"holly_shield": {
-		"name": "Holly\nShield",
+	"holy_shield": {
+		"name": "Holy\nShield",
 		"sprite": 7,
 		"tooltip": "Magically reinforced, stronger than steel\nHealth +200 Vision +50",
 		"attributes": {"hp": 200, "vision": 50},
@@ -113,10 +113,11 @@ const items = {
 		"name": "Magic\nFeather",
 		"sprite": 10,
 		"tooltip": "A feather imbued with magical force\nRegen +2 Speed +15",
-		"attributes": {"regen": 2, "speed": 15},
+		"attributes": {"regen": 2, "speed": 5}, # Other 10 comes from passive
 		"price": 350,
 		"type": "equip",
-		"delivery_time": 15
+		"delivery_time": 15,
+		"passive": "res://items/passives/feather.tscn"
 	},
 	"eye": {
 		"name": "Oligan's\nEye",
@@ -161,19 +162,19 @@ const items = {
 
 func _ready():
 	game = get_tree().get_current_scene()
-	
+
 	hide()
-	
+
 	clear()
-	
-	for item in items: 
+
+	for item in items:
 		var new_item = items[item].duplicate(true)
 		new_item.ready = false
 		new_item.delivered = false
 		add_item(new_item)
-	
+
 	disable_all()
-	
+
 	yield(get_tree(), "idle_frame")
 
 
@@ -182,11 +183,11 @@ func clear():
 		for placeholder_item in equip_items.get_children():
 			equip_items.remove_child(placeholder_item)
 			placeholder_item.queue_free()
-		
+
 		for placeholder_item in consumable_items.get_children():
 			consumable_items.remove_child(placeholder_item)
 			placeholder_item.queue_free()
-		
+
 		cleared = true
 
 
@@ -224,18 +225,18 @@ func update_buttons():
 		if not leader or game.ui.inventories.is_delivering(leader):
 			disable_all()
 			return
-		
+
 				# disable equip if leader is not close to shop
 		if not close_to_blacksmith(leader):
 			disable_equip()
-		
+
 		# enable/disable buttons on which leader don't have enough golds
 		var inventory = game.ui.inventories.get_leader_inventory(leader)
 		if leader and inventory:
 			for item_button in equip_items.get_children() + consumable_items.get_children():
 				var item_price = item_button.item.price
 				item_button.disabled = (leader.gold < item_price)
-		
+
 		# disable buttons if leader don't have empty slots for item
 		if leader and inventory:
 			if !game.ui.inventories.equip_items_has_slots(leader):

--- a/prototype/items/shop.gd
+++ b/prototype/items/shop.gd
@@ -83,10 +83,11 @@ const items = {
 		"name": "Holy\nShield",
 		"sprite": 7,
 		"tooltip": "Magically reinforced, stronger than steel\nHealth +200 Vision +50",
-		"attributes": {"hp": 200, "vision": 50},
+		"attributes": {"hp": 150, "vision": 50},
 		"price": 450,
 		"type": "equip",
-		"delivery_time": 30
+		"delivery_time": 30,
+		"passive": "res://items/passives/holy_shield.tscn" # nearby units +50 health
 	},
 	"scale": {
 		"name": "Dragon\nscale",
@@ -117,7 +118,7 @@ const items = {
 		"price": 350,
 		"type": "equip",
 		"delivery_time": 15,
-		"passive": "res://items/passives/feather.tscn"
+		"passive": "res://items/passives/feather.tscn" # nearby units +10 speed
 	},
 	"eye": {
 		"name": "Oligan's\nEye",

--- a/prototype/unit/unit.tscn
+++ b/prototype/unit/unit.tscn
@@ -120,6 +120,8 @@ script = ExtResource( 15 )
 
 [node name="abilities" type="Node" parent="behavior"]
 
+[node name="item_passives" type="Node" parent="behavior"]
+
 [node name="symbol" type="Sprite" parent="."]
 visible = false
 modulate = Color( 0.32549, 0.584314, 0.709804, 1 )


### PR DESCRIPTION
Item passives are stored as nodes much like the leader abilities and are added once the item is delivered.

The magic feather increases nearby unit speed while the holy shield increases nearby unit health.