### PR TITLE
Fix skills menu when select pawns and enemy leaders

### DIFF
--- a/prototype/ui/buttons/skill_button.gd
+++ b/prototype/ui/buttons/skill_button.gd
@@ -18,7 +18,6 @@ func setup(_skill):
 	_name.text = self.skill.display_name
 	self.hint_tooltip = _skill.description
 
-
 func reset():
 	self.icon = null
 	self._name.text = ""
@@ -55,6 +54,7 @@ func _physics_process(delta):
 		return
 	# We shoudln't see enemy skill's cooldowns
 	if _game.selected_unit.team != _game.player_team:
+		self.disabled = true
 		return
 	if self.skill.on_cooldown():
 		self.disabled = true

--- a/prototype/ui/stats.gd
+++ b/prototype/ui/stats.gd
@@ -18,6 +18,7 @@ onready var portrait_sprite = panel.get_node("portrait/sprite")
 onready var level_label : Label = get_node("panel/portrait/CenterContainer/level_label")
 onready var exp_bar : ProgressBar = get_node("panel/portrait/CenterContainer/exp_bar")
 onready var status_effect_display = $status_effect_display
+onready var active_skills = $active_skills
 
 
 func _ready():
@@ -54,11 +55,13 @@ func update():
 			level_label.text = "Level %d" % unit.level
 			exp_bar.value = unit.experience
 			exp_bar.max_value = unit.experience_needed()
+			active_skills.show()
 		else:
 			gold.visible = false
 			gold_sprite.visible = false
 			level_label.visible = false
 			exp_bar.visible = false
+			active_skills.hide()
 		status_effect_display.prepare(unit.status_effects)
 
 


### PR DESCRIPTION
Closes https://github.com/spicylobstergames/shotcaller-godot/issues/119